### PR TITLE
Feature/verbose

### DIFF
--- a/examples/errors.jl
+++ b/examples/errors.jl
@@ -18,10 +18,10 @@ end
     return solution
 end
 
-@sweep approx_error (refsol, !approx; n = N, nref) -> begin
+@sweep approx_error (refsol, !approx; n = [], nref) -> begin
     @show approx
     @show refsol
     (;error = abs(approx - refsol))
 end
 
-make(approx_error; n=collect(1:10), nref=16)
+make(approx_error, verbosity(:variables); n=collect(1:10), nref=16)

--- a/examples/sweep8.jl
+++ b/examples/sweep8.jl
@@ -31,12 +31,12 @@ end
 # y = make(solutions; seed=[1.0,2.0,3.0], p=3.14)
 
 x = make(average, verbosity(:variables); seed=[1.0,2.0,3.0], p=3.14)
-# y = make(solutions, verbosity(:short); seed=[1.0,2.0,3.0], p=3.14)
+y = make(solutions, verbosity(:variables); seed=[1.0,2.0,3.0], p=3.14)
 
-# @info "Building zs"
-# z1 = sweep(average; seed=Ref([1.0,2.0,3.0]), p=[2.78, 3.14])
-# z2 = sweep(average; seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
+@info "Building zs"
+z1 = sweep(average; seed=Ref([1.0,2.0,3.0]), p=[2.78, 3.14])
+z2 = sweep(average; seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
 
-# @info "Building ws"
-# w1 = sweep(average, over(:p); seed=[1.0,2.0,3.0], p=[2.78, 3.14])
-# w2 = sweep(average, over(:seed, :p); seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
+@info "Building ws"
+w1 = sweep(average, over(:p), verbosity(:variables); seed=[1.0,2.0,3.0], p=[2.78, 3.14])
+w2 = sweep(average, over(:seed, :p), verbosity(:variables); seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])

--- a/examples/sweep8.jl
+++ b/examples/sweep8.jl
@@ -30,13 +30,13 @@ end
 # x = make(average; seed=[1.0,2.0,3.0], p=3.14)
 # y = make(solutions; seed=[1.0,2.0,3.0], p=3.14)
 
-x = make(average, verbosity(:variables); seed=[1.0,2.0,3.0], p=3.14)
-y = make(solutions, verbosity(:variables); seed=[1.0,2.0,3.0], p=3.14)
+x = make(average, verbosity(:full); seed=[1.0,2.0,3.0], p=3.14)
+y = make(solutions, verbosity(:full); seed=[1.0,2.0,3.0], p=3.14)
 
 @info "Building zs"
 z1 = sweep(average; seed=Ref([1.0,2.0,3.0]), p=[2.78, 3.14])
 z2 = sweep(average; seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
 
 @info "Building ws"
-w1 = sweep(average, over(:p), verbosity(:variables); seed=[1.0,2.0,3.0], p=[2.78, 3.14])
-w2 = sweep(average, over(:seed, :p), verbosity(:variables); seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
+w1 = sweep(average, over(:p); seed=[1.0,2.0,3.0], p=[2.78, 3.14])
+w2 = sweep(average, over(:seed, :p); seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])

--- a/examples/sweep8.jl
+++ b/examples/sweep8.jl
@@ -27,13 +27,16 @@ end
     sum(solutions.sol)
 end
 
-x = make(average; seed=[1.0,2.0,3.0], p=3.14)
-y = make(solutions; seed=[1.0,2.0,3.0], p=3.14)
+# x = make(average; seed=[1.0,2.0,3.0], p=3.14)
+# y = make(solutions; seed=[1.0,2.0,3.0], p=3.14)
 
-@info "Building zs"
-z1 = sweep(average; seed=Ref([1.0,2.0,3.0]), p=[2.78, 3.14])
-z2 = sweep(average; seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
+x = make(average; verbosity=:short, seed=[1.0,2.0,3.0], p=3.14)
+# y = make(solutions; verbosity=:short,seed=[1.0,2.0,3.0], p=3.14)
 
-@info "Building ws"
-w1 = sweep(average, over(:p); seed=[1.0,2.0,3.0], p=[2.78, 3.14])
-w2 = sweep(average, over(:seed, :p); seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
+# @info "Building zs"
+# z1 = sweep(average; seed=Ref([1.0,2.0,3.0]), p=[2.78, 3.14])
+# z2 = sweep(average; seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])
+
+# @info "Building ws"
+# w1 = sweep(average, over(:p); seed=[1.0,2.0,3.0], p=[2.78, 3.14])
+# w2 = sweep(average, over(:seed, :p); seed=[[1.0,2.0,3.0], [4.0,5.0,6.0]], p=[2.78, 3.14])

--- a/examples/sweep8.jl
+++ b/examples/sweep8.jl
@@ -30,7 +30,7 @@ end
 # x = make(average; seed=[1.0,2.0,3.0], p=3.14)
 # y = make(solutions; seed=[1.0,2.0,3.0], p=3.14)
 
-x = make(average, verbosity(:full); seed=[1.0,2.0,3.0], p=3.14)
+x = make(average, verbosity(:variables); seed=[1.0,2.0,3.0], p=3.14)
 # y = make(solutions, verbosity(:short); seed=[1.0,2.0,3.0], p=3.14)
 
 # @info "Building zs"

--- a/examples/sweep8.jl
+++ b/examples/sweep8.jl
@@ -30,8 +30,8 @@ end
 # x = make(average; seed=[1.0,2.0,3.0], p=3.14)
 # y = make(solutions; seed=[1.0,2.0,3.0], p=3.14)
 
-x = make(average; verbosity=:short, seed=[1.0,2.0,3.0], p=3.14)
-# y = make(solutions; verbosity=:short,seed=[1.0,2.0,3.0], p=3.14)
+x = make(average, verbosity(:full); seed=[1.0,2.0,3.0], p=3.14)
+# y = make(solutions, verbosity(:short); seed=[1.0,2.0,3.0], p=3.14)
 
 # @info "Building zs"
 # z1 = sweep(average; seed=Ref([1.0,2.0,3.0]), p=[2.78, 3.14])

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -21,7 +21,7 @@ end
 
 struct Verbosity{Level}
     function Verbosity{Level}() where {Level}
-        Level in (:short, :full) || throw(ArgumentError("Verbosity level must be :short or :full, got $(Level)"))
+        Level in (:short, :full, :variables) || throw(ArgumentError("Verbosity level must be :short, :full or :variables, got $(Level)"))
         new{Level}()
     end
 end
@@ -29,7 +29,26 @@ end
 function verbosity(s::Symbol)
     s === :short && return Verbosity{:short}()
     s === :full && return Verbosity{:full}()
-    throw(ArgumentError("verbosity(s::Symbol) expects :short or :full, got $(s)"))
+    s === :variables && return Verbosity{:variables}()
+    throw(ArgumentError("verbosity(s::Symbol) expects :short, :full or :variables, got $(s)"))
+end
+
+_symbolize(k::Symbol) = k
+_symbolize(k::QuoteNode) = k.value
+_symbolize(k) = Symbol(k)
+
+function _merge_active_var_keys(active_var_keys::Set{Symbol}, keys)
+    isempty(keys) && return active_var_keys
+    return union(active_var_keys, Set(_symbolize(k) for k in keys))
+end
+
+function _progress_at(::Verbosity{Level}, kwargs, active_var_keys::Set{Symbol}) where {Level}
+    Level === :full && return " at $(NamedTuple(kwargs))"
+    if Level === :variables
+        filtered = Dict((k, v) for (k, v) in kwargs if k in active_var_keys)
+        return " at $(NamedTuple(filtered))"
+    end
+    return ""
 end
 
 function over(keys...)
@@ -97,26 +116,30 @@ end
 make(target::Target; kwargs...) = make(target, verbosity(:full); kwargs...)
 
 function make(target::Target, v::Verbosity{Level}; kwargs...) where {Level}
-    make(target, v, 0; kwargs...)
+    make(target, v, 0, Set{Symbol}(); kwargs...)
 end
 
 function make(target::Target, v::Verbosity{Level}, level::Int; kwargs...) where {Level}
+    make(target, v, level, Set{Symbol}(); kwargs...)
+end
+
+function make(target::Target, v::Verbosity{Level}, level::Int, active_var_keys::Set{Symbol}; kwargs...) where {Level}
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in target.par_keys))
 
     pfx = ""
-    Level === :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
+    Level !== :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)):"
     Level === :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m:"
 
 
     if cache_uptodate(target; parameters=kwargs)
-        Level === :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        Level !== :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)): retrieved from cache."
         Level === :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
         return target.cache
     end
 
     try_loading(target, level, kwargs)
     if cache_uptodate(target; parameters=kwargs)
-        Level === :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        Level !== :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)): retrieved from disk."
         Level === :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from disk."
         return target.cache
     end
@@ -124,9 +147,9 @@ function make(target::Target, v::Verbosity{Level}, level::Int; kwargs...) where 
     for (t,tf) in zip(target.deps, target.par_tfs)
         kws = tf === nothing ? kwargs : tf(;kwargs...)
         # @show kws
-        make(t, v, level+1; kws...)
+        make(t, v, level+1, active_var_keys; kws...)
     end
-    update!(target, v, level; kwargs...)
+    update!(target, v, level, active_var_keys; kwargs...)
 
     return target.cache
 end
@@ -135,34 +158,39 @@ end
 make(sweep::Sweep; kwargs...) = make(sweep, verbosity(:full); kwargs...)
 
 function make(sweep::Sweep, v::Verbosity{Level}; kwargs...) where {Level}
-    make(sweep, v, 0; kwargs...)
+    make(sweep, v, 0, Set{Symbol}(); kwargs...)
 end
 
 function make(sweep::Sweep, v::Verbosity{Level}, level::Int; kwargs...) where {Level}
+    make(sweep, v, level, Set{Symbol}(); kwargs...)
+end
+
+function make(sweep::Sweep, v::Verbosity{Level}, level::Int, active_var_keys::Set{Symbol}; kwargs...) where {Level}
 
     pfx = "⎵"^level
     pfx = ""
-    Level === :full && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
+    Level !== :short && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)):"
     Level === :short && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m:"
 
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in sweep.par_keys || k in sweep.variable_keys))
     parameters = Dict((k,v) for (k,v) in kwargs if !(k in sweep.variable_keys))
     configs = DrWatson.dict_list(Dict((s, kwargs[s]) for s in sweep.variable_keys))
+    this_level_var_keys = _merge_active_var_keys(active_var_keys, sweep.variable_keys)
 
     if cache_uptodate(sweep; parameters=kwargs)
-        Level === :full && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        Level !== :short && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)): retrieved from cache."
         Level === :short && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from cache."
         return sweep.cache
     end
     try_loading(sweep, level, kwargs)
     if cache_uptodate(sweep; parameters=kwargs)
-        Level === :full && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        Level !== :short && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)): retrieved from disk."
         Level === :short && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from disk."
         return sweep.cache
     end
 
     for t in sweep.shared_deps
-        make(t, v, level+1; parameters...)
+        make(t, v, level+1, active_var_keys; parameters...)
     end
 
     sweep.iteration_timestamps = []
@@ -170,34 +198,35 @@ function make(sweep::Sweep, v::Verbosity{Level}, level::Int; kwargs...) where {L
 
         pfx = "⎵"^(level+1)
         pfx = ""
-        Level === :full && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
+        msg_kwargs = Level === :full ? variables : merge(parameters, variables)
+        Level !== :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m$(_progress_at(v, msg_kwargs, this_level_var_keys)):"
         Level === :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m:"
 
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            Level === :full && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
+            Level !== :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m$(_progress_at(v, msg_kwargs, this_level_var_keys)): retrieved from cache."
             Level === :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from cache."
             continue
         end
         try_loading_iteration(sweep, level+1, variables, parameters)
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            Level === :full && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
+            Level !== :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m$(_progress_at(v, msg_kwargs, this_level_var_keys)): retrieved from disk."
             Level === :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from disk."
             continue
         end
 
         for t in sweep.iteration_deps
-            make(t, v, level+2; parameters..., variables...)
+            make(t, v, level+2, this_level_var_keys; parameters..., variables...)
         end
 
-        iteration_update!(sweep, v, level+1, variables, parameters)
+        iteration_update!(sweep, v, level+1, variables, parameters, this_level_var_keys)
     end
 
-    sweep_update!(sweep, v, level, configs, kwargs, parameters)
+    sweep_update!(sweep, v, level, configs, kwargs, parameters, active_var_keys)
     return sweep.cache
 end
 
 
-function sweep_update!(sweep, ::Verbosity{Level}, level, variables_list, parameters, nonvariables) where {Level}
+function sweep_update!(sweep, v::Verbosity{Level}, level, variables_list, parameters, nonvariables, active_var_keys::Set{Symbol}) where {Level}
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -205,7 +234,7 @@ function sweep_update!(sweep, ::Verbosity{Level}, level, variables_list, paramet
     mkpath(dirname(fullpath))
 
     # collect the results in the .dir folder
-    Level === :full && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
+    Level !== :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m$(_progress_at(v, parameters, active_var_keys)): collect iterations."
     Level === :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m: collect iterations."
 
     df = loadsims(sweep, variables_list, nonvariables)
@@ -224,7 +253,7 @@ function sweep_update!(sweep, ::Verbosity{Level}, level, variables_list, paramet
     #     "tree_hash" => sweep.tree_hash))
 end
 
-function iteration_update!(sweep, ::Verbosity{Level}, level, variables, parameters) where {Level}
+function iteration_update!(sweep, v::Verbosity{Level}, level, variables, parameters, active_var_keys::Set{Symbol}) where {Level}
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -233,8 +262,9 @@ function iteration_update!(sweep, ::Verbosity{Level}, level, variables, paramete
 
     shared_deps_vals = [t.cache for t in sweep.shared_deps]
     iteration_deps_vals = [t.cache for t in sweep.iteration_deps]
+    msg_kwargs = merge(parameters, variables)
 
-    Level === :full && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
+    Level !== :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m$(_progress_at(v, msg_kwargs, active_var_keys)): computing from deps!"
     Level === :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: computing from deps!"    
     sweep.iteration_cache = sweep.recipe(
         shared_deps_vals...,
@@ -259,13 +289,13 @@ function iteration_update!(sweep, ::Verbosity{Level}, level, variables, paramete
     jldsave(fullpath; dct...)
 end
 
-function update!(target::Target, ::Verbosity{Level}, level; kwargs...) where {Level}
+function update!(target::Target, v::Verbosity{Level}, level, active_var_keys::Set{Symbol}; kwargs...) where {Level}
 
     pfx = ""
     fullpath = target_fullpath(target, kwargs)
     mkpath(dirname(fullpath))
 
-    Level === :full && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
+    Level !== :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m$(_progress_at(v, kwargs, active_var_keys)): computing from deps!"
     Level === :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m: computing from deps!"
     target.params = kwargs
     target.cache = target.recipe(getfield.(target.deps, :cache)..., target.weak_deps...; kwargs...)

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -79,21 +79,26 @@ function Target(name, recipe, deps, hash, simname)
     t = Target(deps, recipe, 0.0, nothing, name, hash, simname, nothing)
 end
 
-
-function make(target::Target, level=0; kwargs...)
+# verbose options are :full, :short, :none
+function make(target::Target, level=0; verbose = :full, kwargs...)
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in target.par_keys))
 
     pfx = ""
-    @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
+    verbose == :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
+    verbose == :short && @info "[$level]$(pfx) making \e[32m$(target.name):"
+
 
     if cache_uptodate(target; parameters=kwargs)
         @info "\e[34m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        verbose == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        verbose == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
         return target.cache
     end
 
     try_loading(target, level, kwargs)
     if cache_uptodate(target; parameters=kwargs)
-        @info "\e[35m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        verbose == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        verbose == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from disk."
         return target.cache
     end
 
@@ -108,23 +113,26 @@ function make(target::Target, level=0; kwargs...)
 end
 
 
-function make(sweep::Sweep, level=0; kwargs...)
+function make(sweep::Sweep, level=0;verbose = :full, kwargs...)
 
     pfx = "⎵"^level
     pfx = ""
-    @info "[$level]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
+    verbose == :full && @info "[$level]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
+    verbose == :short && @info "[$level]$(pfx) making \e[32m$(sweep.name)\e[0m:"
 
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in sweep.par_keys || k in sweep.variable_keys))
     parameters = Dict((k,v) for (k,v) in kwargs if !(k in sweep.variable_keys))
     configs = DrWatson.dict_list(Dict((s, kwargs[s]) for s in sweep.variable_keys))
 
     if cache_uptodate(sweep; parameters=kwargs)
-        @info "\e[34m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        verbose == :full && @info "\e[34m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        verbose == :short && @info "\e[34m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m: retrieved from cache."
         return sweep.cache
     end
     try_loading(sweep, level, kwargs)
     if cache_uptodate(sweep; parameters=kwargs)
-        @info "\e[35m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        verbose == :full && @info "\e[35m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        verbose == :short && @info "\e[35m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m: retrieved from disk."
         return sweep.cache
     end
 
@@ -137,31 +145,34 @@ function make(sweep::Sweep, level=0; kwargs...)
 
         pfx = "⎵"^(level+1)
         pfx = ""
-        @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
+        verbose == :full && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
+        verbose == :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m:"
 
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
+            verbose == :full && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
+            verbose == :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from cache."
             continue
         end
         try_loading_iteration(sweep, level+1, variables, parameters)
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
+            verbose == :full && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
+            verbose == :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from disk."
             continue
         end
 
         for t in sweep.iteration_deps
-            make(t, level+2; parameters..., variables...)
+            make(t, level+2;verbose=verbose, parameters..., variables...)
         end
 
         iteration_update!(sweep, level+1, variables, parameters)
     end
 
-    sweep_update!(sweep, level, configs, kwargs, parameters)
+    sweep_update!(sweep, level, configs, kwargs, parameters;verbose=verbose)
     return sweep.cache
 end
 
 
-function sweep_update!(sweep, level, variables_list, parameters, nonvariables)
+function sweep_update!(sweep, level, variables_list, parameters, nonvariables; verbose = :full)
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -169,7 +180,9 @@ function sweep_update!(sweep, level, variables_list, parameters, nonvariables)
     mkpath(dirname(fullpath))
 
     # collect the results in the .dir folder
-    @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
+    verbose == :full && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
+    verbose == :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m: collect iterations."
+
     df = loadsims(sweep, variables_list, nonvariables)
     select!(df, Not([:timestamp, :hash, :path, :params, :tree_hash]))
 
@@ -186,7 +199,7 @@ function sweep_update!(sweep, level, variables_list, parameters, nonvariables)
     #     "tree_hash" => sweep.tree_hash))
 end
 
-function iteration_update!(sweep, level, variables, parameters)
+function iteration_update!(sweep, level, variables, parameters;verbose = :full)
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -196,7 +209,8 @@ function iteration_update!(sweep, level, variables, parameters)
     shared_deps_vals = [t.cache for t in sweep.shared_deps]
     iteration_deps_vals = [t.cache for t in sweep.iteration_deps]
 
-    @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
+    verbose == :full && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
+    verbose == :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: computing from deps!"    
     sweep.iteration_cache = sweep.recipe(
         shared_deps_vals...,
         iteration_deps_vals...,
@@ -220,13 +234,14 @@ function iteration_update!(sweep, level, variables, parameters)
     jldsave(fullpath; dct...)
 end
 
-function update!(target::Target, level; kwargs...)
+function update!(target::Target, level; verbose = :full, kwargs...)
 
     pfx = ""
     fullpath = target_fullpath(target, kwargs)
     mkpath(dirname(fullpath))
 
-    @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
+    verbose == :full && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
+    verbose == :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m: computing from deps!"
     target.params = kwargs
     target.cache = target.recipe(getfield.(target.deps, :cache)..., target.weak_deps...; kwargs...)
     target.timestamp = time()

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -79,64 +79,64 @@ function Target(name, recipe, deps, hash, simname)
     t = Target(deps, recipe, 0.0, nothing, name, hash, simname, nothing)
 end
 
-# verbose options are :full, :short, :none
-function make(target::Target, level=0; verbose = :full, kwargs...)
+# verbosity options are :full, :short, :none
+function make(target::Target, level=0; verbosity = :full, kwargs...)
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in target.par_keys))
 
     pfx = ""
-    verbose == :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
-    verbose == :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m:"
+    verbosity == :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
+    verbosity == :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m:"
 
 
     if cache_uptodate(target; parameters=kwargs)
-        verbose == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
-        verbose == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
+        verbosity == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        verbosity == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
         return target.cache
     end
 
     try_loading(target, level, kwargs)
     if cache_uptodate(target; parameters=kwargs)
-        verbose == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
-        verbose == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from disk."
+        verbosity == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        verbosity == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from disk."
         return target.cache
     end
 
     for (t,tf) in zip(target.deps, target.par_tfs)
         kws = tf === nothing ? kwargs : tf(;kwargs...)
         # @show kws
-        make(t, level+1;verbose=verbose, kws...)
+        make(t, level+1;verbosity=verbosity, kws...)
     end
-    update!(target, level; verbose=verbose, kwargs...)
+    update!(target, level; verbosity=verbosity, kwargs...)
 
     return target.cache
 end
 
 
-function make(sweep::Sweep, level=0;verbose = :full, kwargs...)
+function make(sweep::Sweep, level=0;verbosity = :full, kwargs...)
 
     pfx = "⎵"^level
     pfx = ""
-    verbose == :full && @info "[$level]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
-    verbose == :short && @info "[$level]$(pfx) making \e[32m$(sweep.name)\e[0m:"
+    verbosity == :full && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
+    verbosity == :short && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m:"
 
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in sweep.par_keys || k in sweep.variable_keys))
     parameters = Dict((k,v) for (k,v) in kwargs if !(k in sweep.variable_keys))
     configs = DrWatson.dict_list(Dict((s, kwargs[s]) for s in sweep.variable_keys))
 
     if cache_uptodate(sweep; parameters=kwargs)
-        verbose == :full && @info "\e[34m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
-        verbose == :short && @info "\e[34m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m: retrieved from cache."
+        verbosity == :full && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        verbosity == :short && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from cache."
         return sweep.cache
     end
     try_loading(sweep, level, kwargs)
     if cache_uptodate(sweep; parameters=kwargs)
-        verbose == :full && @info "\e[35m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
-        verbose == :short && @info "\e[35m[$level]\e[0m$(pfx) sweep  \e[32m$(sweep.name)\e[0m: retrieved from disk."
+        verbosity == :full && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        verbosity == :short && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from disk."
         return sweep.cache
     end
 
     for t in sweep.shared_deps
-        make(t, level+1; parameters...)
+        make(t, level+1; verbosity, parameters...)
     end
 
     sweep.iteration_timestamps = []
@@ -144,34 +144,34 @@ function make(sweep::Sweep, level=0;verbose = :full, kwargs...)
 
         pfx = "⎵"^(level+1)
         pfx = ""
-        verbose == :full && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
-        verbose == :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m:"
+        verbosity == :full && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
+        verbosity == :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m:"
 
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            verbose == :full && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
-            verbose == :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from cache."
+            verbosity == :full && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
+            verbosity == :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from cache."
             continue
         end
         try_loading_iteration(sweep, level+1, variables, parameters)
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            verbose == :full && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
-            verbose == :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from disk."
+            verbosity == :full && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
+            verbosity == :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from disk."
             continue
         end
 
         for t in sweep.iteration_deps
-            make(t, level+2;verbose=verbose, parameters..., variables...)
+            make(t, level+2;verbosity=verbosity, parameters..., variables...)
         end
 
-        iteration_update!(sweep, level+1, variables, parameters)
+        iteration_update!(sweep, level+1, variables, parameters; verbosity)
     end
 
-    sweep_update!(sweep, level, configs, kwargs, parameters;verbose=verbose)
+    sweep_update!(sweep, level, configs, kwargs, parameters;verbosity=verbosity)
     return sweep.cache
 end
 
 
-function sweep_update!(sweep, level, variables_list, parameters, nonvariables; verbose = :full)
+function sweep_update!(sweep, level, variables_list, parameters, nonvariables; verbosity = :full)
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -179,8 +179,8 @@ function sweep_update!(sweep, level, variables_list, parameters, nonvariables; v
     mkpath(dirname(fullpath))
 
     # collect the results in the .dir folder
-    verbose == :full && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
-    verbose == :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m: collect iterations."
+    verbosity == :full && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
+    verbosity == :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m: collect iterations."
 
     df = loadsims(sweep, variables_list, nonvariables)
     select!(df, Not([:timestamp, :hash, :path, :params, :tree_hash]))
@@ -198,7 +198,7 @@ function sweep_update!(sweep, level, variables_list, parameters, nonvariables; v
     #     "tree_hash" => sweep.tree_hash))
 end
 
-function iteration_update!(sweep, level, variables, parameters;verbose = :full)
+function iteration_update!(sweep, level, variables, parameters;verbosity = :full)
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -208,8 +208,8 @@ function iteration_update!(sweep, level, variables, parameters;verbose = :full)
     shared_deps_vals = [t.cache for t in sweep.shared_deps]
     iteration_deps_vals = [t.cache for t in sweep.iteration_deps]
 
-    verbose == :full && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
-    verbose == :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: computing from deps!"    
+    verbosity == :full && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
+    verbosity == :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: computing from deps!"    
     sweep.iteration_cache = sweep.recipe(
         shared_deps_vals...,
         iteration_deps_vals...,
@@ -233,14 +233,14 @@ function iteration_update!(sweep, level, variables, parameters;verbose = :full)
     jldsave(fullpath; dct...)
 end
 
-function update!(target::Target, level; verbose = :full, kwargs...)
+function update!(target::Target, level; verbosity = :full, kwargs...)
 
     pfx = ""
     fullpath = target_fullpath(target, kwargs)
     mkpath(dirname(fullpath))
 
-    verbose == :full && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
-    verbose == :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m: computing from deps!"
+    verbosity == :full && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
+    verbosity == :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m: computing from deps!"
     target.params = kwargs
     target.cache = target.recipe(getfield.(target.deps, :cache)..., target.weak_deps...; kwargs...)
     target.timestamp = time()

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -580,6 +580,16 @@ end
 
 
 function sweep(t::Target; kwargs...)
+    sweep(t, verbosity(:full); kwargs...)
+end
+
+
+function sweep(t::Target, s::Symbol; kwargs...)
+    sweep(t, verbosity(s); kwargs...)
+end
+
+
+function sweep(t::Target, v::Verbosity{Level}; kwargs...) where {Level}
 
     tname = Symbol(t.name)
 
@@ -652,11 +662,21 @@ function sweep(t::Target; kwargs...)
     append_deps_parameter_keys!(sweep, sweep.par_keys)
     sweep.tree_hash = Makeitso.target_hash(sweep, hash(nothing))
 
-    df = make(sweep; vars..., params...)
+    df = make(sweep, v; vars..., params...)
 end
 
 
 function sweep(t::Target, o::Over; kwargs...)
+    sweep(t, o, verbosity(:full); kwargs...)
+end
+
+
+function sweep(t::Target, o::Over, s::Symbol; kwargs...)
+    sweep(t, o, verbosity(s); kwargs...)
+end
+
+
+function sweep(t::Target, o::Over, v::Verbosity{Level}; kwargs...) where {Level}
 
     tname = Symbol(t.name)
 
@@ -719,7 +739,7 @@ function sweep(t::Target, o::Over; kwargs...)
     append_deps_parameter_keys!(sweep, sweep.par_keys)
     sweep.tree_hash = Makeitso.target_hash(sweep, hash(nothing))
 
-    df = make(sweep; vars..., params...)
+    df = make(sweep, v; vars..., params...)
 end
 
 

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -85,11 +85,10 @@ function make(target::Target, level=0; verbose = :full, kwargs...)
 
     pfx = ""
     verbose == :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
-    verbose == :short && @info "[$level]$(pfx) making \e[32m$(target.name):"
+    verbose == :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m:"
 
 
     if cache_uptodate(target; parameters=kwargs)
-        @info "\e[34m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
         verbose == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
         verbose == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
         return target.cache
@@ -105,9 +104,9 @@ function make(target::Target, level=0; verbose = :full, kwargs...)
     for (t,tf) in zip(target.deps, target.par_tfs)
         kws = tf === nothing ? kwargs : tf(;kwargs...)
         # @show kws
-        make(t, level+1; kws...)
+        make(t, level+1;verbose=verbose, kws...)
     end
-    update!(target, level; kwargs...)
+    update!(target, level; verbose=verbose, kwargs...)
 
     return target.cache
 end

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -43,9 +43,13 @@ function _merge_active_var_keys(active_var_keys::Set{Symbol}, keys)
 end
 
 function _progress_at(::Verbosity{Level}, kwargs, active_var_keys::Set{Symbol}) where {Level}
-    Level === :full && return " at $(NamedTuple(kwargs))"
+    if Level === :full
+        isempty(kwargs) && return ""
+        return " at $(NamedTuple(kwargs))"
+    end
     if Level === :variables
         filtered = Dict((k, v) for (k, v) in kwargs if k in active_var_keys)
+        isempty(filtered) && return ""
         return " at $(NamedTuple(filtered))"
     end
     return ""

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -12,10 +12,24 @@ export @sweep, @sweep2
 export make, sweep
 export over
 export getrow
+export verbosity
 
 
 struct Over
     keys::Vector{Symbol}
+end
+
+struct Verbosity{Level}
+    function Verbosity{Level}() where {Level}
+        Level in (:short, :full) || throw(ArgumentError("Verbosity level must be :short or :full, got $(Level)"))
+        new{Level}()
+    end
+end
+
+function verbosity(s::Symbol)
+    s === :short && return Verbosity{:short}()
+    s === :full && return Verbosity{:full}()
+    throw(ArgumentError("verbosity(s::Symbol) expects :short or :full, got $(s)"))
 end
 
 function over(keys...)
@@ -79,64 +93,76 @@ function Target(name, recipe, deps, hash, simname)
     t = Target(deps, recipe, 0.0, nothing, name, hash, simname, nothing)
 end
 
-# verbosity options are :full, :short, :none
-function make(target::Target, level=0; verbosity = :full, kwargs...)
+# default verbosity is :full
+make(target::Target; kwargs...) = make(target, verbosity(:full); kwargs...)
+
+function make(target::Target, v::Verbosity{Level}; kwargs...) where {Level}
+    make(target, v, 0; kwargs...)
+end
+
+function make(target::Target, v::Verbosity{Level}, level::Int; kwargs...) where {Level}
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in target.par_keys))
 
     pfx = ""
-    verbosity == :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
-    verbosity == :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m:"
+    Level === :full && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)):"
+    Level === :short && @info "[$level]$(pfx) making \e[32m$(target.name)\e[0m:"
 
 
     if cache_uptodate(target; parameters=kwargs)
-        verbosity == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
-        verbosity == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
+        Level === :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        Level === :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from cache."
         return target.cache
     end
 
     try_loading(target, level, kwargs)
     if cache_uptodate(target; parameters=kwargs)
-        verbosity == :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
-        verbosity == :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from disk."
+        Level === :full && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        Level === :short && @info "[$level]$(pfx) target \e[32m$(target.name)\e[0m: retrieved from disk."
         return target.cache
     end
 
     for (t,tf) in zip(target.deps, target.par_tfs)
         kws = tf === nothing ? kwargs : tf(;kwargs...)
         # @show kws
-        make(t, level+1;verbosity=verbosity, kws...)
+        make(t, v, level+1; kws...)
     end
-    update!(target, level; verbosity=verbosity, kwargs...)
+    update!(target, v, level; kwargs...)
 
     return target.cache
 end
 
 
-function make(sweep::Sweep, level=0;verbosity = :full, kwargs...)
+make(sweep::Sweep; kwargs...) = make(sweep, verbosity(:full); kwargs...)
+
+function make(sweep::Sweep, v::Verbosity{Level}; kwargs...) where {Level}
+    make(sweep, v, 0; kwargs...)
+end
+
+function make(sweep::Sweep, v::Verbosity{Level}, level::Int; kwargs...) where {Level}
 
     pfx = "⎵"^level
     pfx = ""
-    verbosity == :full && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
-    verbosity == :short && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m:"
+    Level === :full && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)):"
+    Level === :short && @info "[$level]$(pfx) sweeping \e[32m$(sweep.name)\e[0m:"
 
     kwargs = Dict((k,v) for (k,v) in kwargs if (k in sweep.par_keys || k in sweep.variable_keys))
     parameters = Dict((k,v) for (k,v) in kwargs if !(k in sweep.variable_keys))
     configs = DrWatson.dict_list(Dict((s, kwargs[s]) for s in sweep.variable_keys))
 
     if cache_uptodate(sweep; parameters=kwargs)
-        verbosity == :full && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
-        verbosity == :short && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from cache."
+        Level === :full && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from cache."
+        Level === :short && @info "\e[34m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from cache."
         return sweep.cache
     end
     try_loading(sweep, level, kwargs)
     if cache_uptodate(sweep; parameters=kwargs)
-        verbosity == :full && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
-        verbosity == :short && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from disk."
+        Level === :full && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m at $(NamedTuple(kwargs)): retrieved from disk."
+        Level === :short && @info "\e[35m[$level]\e[0m$(pfx) sweep \e[32m$(sweep.name)\e[0m: retrieved from disk."
         return sweep.cache
     end
 
     for t in sweep.shared_deps
-        make(t, level+1; verbosity, parameters...)
+        make(t, v, level+1; parameters...)
     end
 
     sweep.iteration_timestamps = []
@@ -144,34 +170,34 @@ function make(sweep::Sweep, level=0;verbosity = :full, kwargs...)
 
         pfx = "⎵"^(level+1)
         pfx = ""
-        verbosity == :full && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
-        verbosity == :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m:"
+        Level === :full && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)):"
+        Level === :short && @info "[$(level+1)]$(pfx) making \e[32m$(sweep.name)\e[0m:"
 
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            verbosity == :full && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
-            verbosity == :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from cache."
+            Level === :full && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from cache."
+            Level === :short && @info "\e[34m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from cache."
             continue
         end
         try_loading_iteration(sweep, level+1, variables, parameters)
         if iteration_cache_uptodate(sweep; parameters..., variables...)
-            verbosity == :full && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
-            verbosity == :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from disk."
+            Level === :full && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(variables)): retrieved from disk."
+            Level === :short && @info "\e[35m[$(level+1)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: retrieved from disk."
             continue
         end
 
         for t in sweep.iteration_deps
-            make(t, level+2;verbosity=verbosity, parameters..., variables...)
+            make(t, v, level+2; parameters..., variables...)
         end
 
-        iteration_update!(sweep, level+1, variables, parameters; verbosity)
+        iteration_update!(sweep, v, level+1, variables, parameters)
     end
 
-    sweep_update!(sweep, level, configs, kwargs, parameters;verbosity=verbosity)
+    sweep_update!(sweep, v, level, configs, kwargs, parameters)
     return sweep.cache
 end
 
 
-function sweep_update!(sweep, level, variables_list, parameters, nonvariables; verbosity = :full)
+function sweep_update!(sweep, ::Verbosity{Level}, level, variables_list, parameters, nonvariables) where {Level}
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -179,8 +205,8 @@ function sweep_update!(sweep, level, variables_list, parameters, nonvariables; v
     mkpath(dirname(fullpath))
 
     # collect the results in the .dir folder
-    verbosity == :full && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
-    verbosity == :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m: collect iterations."
+    Level === :full && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m at $(NamedTuple(parameters)): collect iterations."
+    Level === :short && @info "[$level]$(pfx) sweep  \e[32m$(sweep.name)\e[0m: collect iterations."
 
     df = loadsims(sweep, variables_list, nonvariables)
     select!(df, Not([:timestamp, :hash, :path, :params, :tree_hash]))
@@ -198,7 +224,7 @@ function sweep_update!(sweep, level, variables_list, parameters, nonvariables; v
     #     "tree_hash" => sweep.tree_hash))
 end
 
-function iteration_update!(sweep, level, variables, parameters;verbosity = :full)
+function iteration_update!(sweep, ::Verbosity{Level}, level, variables, parameters) where {Level}
 
     pfx = "⎵"^(level)
     pfx = ""
@@ -208,8 +234,8 @@ function iteration_update!(sweep, level, variables, parameters;verbosity = :full
     shared_deps_vals = [t.cache for t in sweep.shared_deps]
     iteration_deps_vals = [t.cache for t in sweep.iteration_deps]
 
-    verbosity == :full && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
-    verbosity == :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: computing from deps!"    
+    Level === :full && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m at $(NamedTuple(merge(parameters, variables))): computing from deps!"
+    Level === :short && @info "\e[38;5;208m[$(level)]\e[0m$(pfx) target \e[32m$(sweep.name)\e[0m: computing from deps!"    
     sweep.iteration_cache = sweep.recipe(
         shared_deps_vals...,
         iteration_deps_vals...,
@@ -233,14 +259,14 @@ function iteration_update!(sweep, level, variables, parameters;verbosity = :full
     jldsave(fullpath; dct...)
 end
 
-function update!(target::Target, level; verbosity = :full, kwargs...)
+function update!(target::Target, ::Verbosity{Level}, level; kwargs...) where {Level}
 
     pfx = ""
     fullpath = target_fullpath(target, kwargs)
     mkpath(dirname(fullpath))
 
-    verbosity == :full && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
-    verbosity == :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m: computing from deps!"
+    Level === :full && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m at $(NamedTuple(kwargs)): computing from deps!"
+    Level === :short && @info "\e[38;5;208m[$level]\e[0m$(pfx) target \e[32m$(target.name)\e[0m: computing from deps!"
     target.params = kwargs
     target.cache = target.recipe(getfield.(target.deps, :cache)..., target.weak_deps...; kwargs...)
     target.timestamp = time()

--- a/src/Makeitso.jl
+++ b/src/Makeitso.jl
@@ -116,8 +116,8 @@ function Target(name, recipe, deps, hash, simname)
     t = Target(deps, recipe, 0.0, nothing, name, hash, simname, nothing)
 end
 
-# default verbosity is :full
-make(target::Target; kwargs...) = make(target, verbosity(:full); kwargs...)
+# default verbosity is :variables
+make(target::Target; kwargs...) = make(target, verbosity(:variables); kwargs...)
 
 function make(target::Target, v::Verbosity{Level}; kwargs...) where {Level}
     make(target, v, 0, Set{Symbol}(); kwargs...)
@@ -159,7 +159,7 @@ function make(target::Target, v::Verbosity{Level}, level::Int, active_var_keys::
 end
 
 
-make(sweep::Sweep; kwargs...) = make(sweep, verbosity(:full); kwargs...)
+make(sweep::Sweep; kwargs...) = make(sweep, verbosity(:variables); kwargs...)
 
 function make(sweep::Sweep, v::Verbosity{Level}; kwargs...) where {Level}
     make(sweep, v, 0, Set{Symbol}(); kwargs...)
@@ -580,7 +580,7 @@ end
 
 
 function sweep(t::Target; kwargs...)
-    sweep(t, verbosity(:full); kwargs...)
+    sweep(t, verbosity(:variables); kwargs...)
 end
 
 
@@ -667,7 +667,7 @@ end
 
 
 function sweep(t::Target, o::Over; kwargs...)
-    sweep(t, o, verbosity(:full); kwargs...)
+    sweep(t, o, verbosity(:variables); kwargs...)
 end
 
 


### PR DESCRIPTION
create verbose field in make and sweep such that the terminal is not spammed when large parameters such as meshes are passed into a target.
the :short option shows everything without the parameters, the default :full option shows the original messages,
:none (or wathever you like) shows nothing